### PR TITLE
If $COMPOSER_BIN_DIR is defined, remove it from the beginning of $PATH

### DIFF
--- a/bin/shellcheck
+++ b/bin/shellcheck
@@ -41,6 +41,15 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# When run as part of a Composer script, the bin-dir will be pushed to the front of the $PATH.
+#
+# However, this can lead to recursion since the first "shellcheck" script `command -v shellcheck`
+# will find will be...well, this one.
+if [[ -n "$COMPOSER_BIN_DIR" ]]; then
+    # shellcheck disable=SC2001
+    PATH="$(sed -e "s|^${COMPOSER_BIN_DIR}:||" <<< "$PATH")"
+fi
+
 # Find the local ShellCheck binary.
 shellcheck="$(command -v shellcheck)"
 


### PR DESCRIPTION
When running Composer scripts, Composer will prepend its bin-dir to the user's `$PATH`.

However, this causes issues when we're running a script named "shellcheck" and we're looking for "shellcheck" in the user's path.

If we find the `$COMPOSER_BIN_DIR` environment variable, strip it from the beginning of the user's `$PATH` so we can find the *real* ShellCheck.

Fixes #2.